### PR TITLE
Django 1.6 compatibility

### DIFF
--- a/solo/admin.py
+++ b/solo/admin.py
@@ -1,9 +1,12 @@
-from django.conf.urls import patterns, url
 from django.contrib import admin
 from django.http import HttpResponseRedirect
 from django.utils.encoding import force_unicode
 from django.utils.translation import ugettext as _
 
+try:
+    from django.conf.urls.defaults import url, patterns
+except ImportError:
+    from django.conf.urls import url, patterns
 
 class SingletonModelAdmin(admin.ModelAdmin):
     object_history_template = "admin/solo/object_history.html"


### PR DESCRIPTION
The utility functions in django.conf.urls.defaults moved to django.conf.urls (old location was deprecated in 1.3 and completely removed in 1.6)
