### PR TITLE
Workaround to make import of django.utils.encoding.force_unicode work in...

### DIFF
--- a/solo/admin.py
+++ b/solo/admin.py
@@ -1,7 +1,10 @@
 from django.conf.urls import url, patterns
 from django.contrib import admin
 from django.http import HttpResponseRedirect
-from django.utils.encoding import force_unicode
+try:
+    from django.utils.encoding import force_unicode
+except ImportError:
+    from django.utils.encoding import force_text as force_unicode 
 from django.utils.translation import ugettext as _
 
 


### PR DESCRIPTION
... newer versions of Django and/or Python.
