### PR TITLE
Added 'load url from future' so templates work with Django 1.4

### DIFF
--- a/solo/templates/admin/solo/change_form.html
+++ b/solo/templates/admin/solo/change_form.html
@@ -1,6 +1,7 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 {% load admin_urls %}
+{% load url from future %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/solo/templates/admin/solo/object_history.html
+++ b/solo/templates/admin/solo/object_history.html
@@ -1,5 +1,6 @@
 {% extends "admin/object_history.html" %}
 {% load i18n %}
+{% load url from future %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">


### PR DESCRIPTION
URL lookup for 'admin:index' throws NoReverseMatch without this in 1.4
