### PR TITLE
update for solo admin to display singular name, fix for model_name

### DIFF
--- a/solo/admin.py
+++ b/solo/admin.py
@@ -20,9 +20,12 @@ class SingletonModelAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         urls = super(SingletonModelAdmin, self).get_urls()
+
+        self.model._meta.verbose_name_plural = self.model._meta.verbose_name
+        
         url_name_prefix = '%(app_name)s_%(model_name)s' % {
             'app_name': self.model._meta.app_label,
-            'model_name': self.model._meta.module_name,
+            'model_name': self.model._meta.model_name,
         }
         custom_urls = patterns('',
             url(r'^history/$',


### PR DESCRIPTION
As discussed, this will ensure the plural name is not used for in the model admin.
