### PR TITLE
remove 'load url from future' tag from template (Django 1.9)

### DIFF
--- a/solo/templates/admin/solo/change_form.html
+++ b/solo/templates/admin/solo/change_form.html
@@ -1,7 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 {% load admin_urls %}
-{% load url from future %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">

--- a/solo/templates/admin/solo/object_history.html
+++ b/solo/templates/admin/solo/object_history.html
@@ -1,6 +1,5 @@
 {% extends "admin/object_history.html" %}
 {% load i18n %}
-{% load url from future %}
 
 {% block breadcrumbs %}
 <div class="breadcrumbs">


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/internals/deprecation/#deprecation-removed-in-1-9

> ssi and url template tags will be removed from the future template tag library (used during the 1.3/1.4 deprecation period).

Exception with Django 1.9:
> TemplateSyntaxError at <…>
>
> 'url' is not a valid tag or filter in tag library 'future'