### PR TITLE
Update custom_urls in admin.py due to deprecation warning

### DIFF
--- a/solo/admin.py
+++ b/solo/admin.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.contrib import admin
 from django.http import HttpResponseRedirect
 try:
@@ -33,7 +33,7 @@ class SingletonModelAdmin(admin.ModelAdmin):
             'app_name': self.model._meta.app_label,
             'model_name': model_name,
         }
-        custom_urls = patterns('',
+        custom_urls = [
             url(r'^history/$',
                 self.admin_site.admin_view(self.history_view),
                 {'object_id': '1'},
@@ -42,7 +42,7 @@ class SingletonModelAdmin(admin.ModelAdmin):
                 self.admin_site.admin_view(self.change_view),
                 {'object_id': '1'},
                 name='%s_change' % url_name_prefix),
-        )
+        ]
         # By inserting the custom URLs first, we overwrite the standard URLs.
         return custom_urls + urls
 


### PR DESCRIPTION
Fixes #37.

django.conf.urls.patterns() is deprecated and will be removed in Django 1.10.