### PR TITLE
Elaborated on usage of the template tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,30 @@ Example:
     {{ site_config.maintenance_mode }}
 
 
+If you're extending a template, be sure to use the tag in the proper scope.
+
+Right:
+
+    {% extends "index.html" %}
+    {% load solo_tags %}
+    
+    {% block content %}
+        {% get_solo 'config.SiteConfiguration' as site_config %}
+        {{ site_config.site_name }}
+    {% endblock content %}
+
+Wrong:
+
+    {% extends "index.html" %}
+    {% load solo_tags %}
+    {% get_solo 'config.SiteConfiguration' as site_config %}
+    
+    {% block content %}
+        {{ site_config.site_name }}
+    {% endblock content %}
+
+
+
 Caching
 -------
 


### PR DESCRIPTION
I ran into an error where I called the tag in the wrong scope so the context variable wasn't available.  This might clarify the usage for some users.