### PR TITLE
Added support for configuring the pk value of the singleton instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Usage Example
 In your model, note how you did not have to provide a `verbose_name_plural` field -
 That's because Django Solo uses the `verbose_name` instead.
 
-If you're changing an existing model (which already has some objects stored in the database) to a singleton model, you can explicitly provide the id of the row in the database to use by django-solo as singleton. This can be done by setting `singleton_instance_id` property on the model`:
+If you're changing an existing model (which already has some objects stored in the database) to a singleton model, you can explicitly provide the id of the row in the database for django-solo to use. This can be done by setting `singleton_instance_id` property on the model:
 
     class SiteConfiguration(SingletonModel):
         singleton_instance_id = 24

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Usage Example
 In your model, note how you did not have to provide a `verbose_name_plural` field -
 That's because Django Solo uses the `verbose_name` instead.
 
+If you're changing an existing model (which already has some objects stored in the database) to a singleton model, you can explicitly provide the id of the row in the database to use by django-solo as singleton. This can be done by setting `singleton_instance_id` property on the model`:
+
+    class SiteConfiguration(SingletonModel):
+        singleton_instance_id = 24
+        # (...)
 
 Installation
 ------------

--- a/solo/admin.py
+++ b/solo/admin.py
@@ -39,11 +39,11 @@ class SingletonModelAdmin(admin.ModelAdmin):
         custom_urls = patterns('',
             url(r'^history/$',
                 self.admin_site.admin_view(self.history_view),
-                {'object_id': str(self.singleton_pk)},
+                {'object_id': str(self.singleton_instance_id)},
                 name='%s_history' % url_name_prefix),
             url(r'^$',
                 self.admin_site.admin_view(self.change_view),
-                {'object_id': str(self.singleton_pk)},
+                {'object_id': str(self.singleton_instance_id)},
                 name='%s_change' % url_name_prefix),
         )
         # By inserting the custom URLs first, we overwrite the standard URLs.
@@ -59,8 +59,8 @@ class SingletonModelAdmin(admin.ModelAdmin):
             return HttpResponseRedirect("../../")
 
     def change_view(self, request, object_id, extra_context=None):
-        if object_id == str(self.singleton_pk):
-            self.model.objects.get_or_create(pk=self.singleton_pk)
+        if object_id == str(self.singleton_instance_id):
+            self.model.objects.get_or_create(pk=self.singleton_instance_id)
         return super(SingletonModelAdmin, self).change_view(
             request,
             object_id,
@@ -68,5 +68,5 @@ class SingletonModelAdmin(admin.ModelAdmin):
         )
 
     @property
-    def singleton_pk(self):
+    def singleton_instance_id(self):
         return getattr(self.model, 'singleton_instance_id', DEFAULT_SINGLETON_INSTANCE_ID)

--- a/solo/models.py
+++ b/solo/models.py
@@ -9,13 +9,16 @@ except ImportError:
 
 from solo import settings as solo_settings
 
+DEFAULT_SINGLETON_INSTANCE_ID = 1
 
 class SingletonModel(models.Model):
+    singleton_instance_id = DEFAULT_SINGLETON_INSTANCE_ID
+
     class Meta:
         abstract = True
 
     def save(self, *args, **kwargs):
-        self.pk = 1
+        self.pk = self.singleton_instance_id
         self.set_to_cache()
         super(SingletonModel, self).save(*args, **kwargs)
 
@@ -40,12 +43,12 @@ class SingletonModel(models.Model):
     def get_solo(cls):
         cache_name = getattr(settings, 'SOLO_CACHE', solo_settings.SOLO_CACHE)
         if not cache_name:
-            obj, created = cls.objects.get_or_create(pk=1)
+            obj, created = cls.objects.get_or_create(pk=cls.singleton_instance_id)
             return obj
         cache = get_cache(cache_name)
         cache_key = cls.get_cache_key()
         obj = cache.get(cache_key)
         if not obj:
-            obj, created = cls.objects.get_or_create(pk=1)
+            obj, created = cls.objects.get_or_create(pk=cls.singleton_instance_id)
             obj.set_to_cache()
         return obj

--- a/solo/tests/models.py
+++ b/solo/tests/models.py
@@ -11,3 +11,14 @@ class SiteConfiguration(SingletonModel):
 
     class Meta:
         verbose_name = "Site Configuration"
+
+
+class SiteConfigurationWithExplicitlyGivenId(SingletonModel):
+    singleton_instance_id = 24
+    site_name = models.CharField(max_length=255, default='Default Config')
+
+    def __unicode__(self):
+        return "Site Configuration"
+
+    class Meta:
+        verbose_name = "Site Configuration"

--- a/solo/tests/tests.py
+++ b/solo/tests/tests.py
@@ -3,10 +3,10 @@ from django.test import TestCase
 
 from django.test.utils import override_settings
 from solo.models import get_cache
-from solo.tests.models import SiteConfiguration
+from solo.tests.models import SiteConfiguration, SiteConfigurationWithExplicitlyGivenId
 
 
-class SigletonTest(TestCase):
+class SingletonTest(TestCase):
 
     def setUp(self):
         self.template = Template(
@@ -51,3 +51,13 @@ class SigletonTest(TestCase):
         self.assertNotIn('Config In Cache', output)
         self.assertNotIn('Default Config', output)
         self.assertIn('Config In Database', output)
+
+
+class SingletonWithExplicitIdTest(TestCase):
+
+    def setUp(self):
+        SiteConfigurationWithExplicitlyGivenId.objects.all().delete()
+
+    def test_when_singleton_instance_id_is_given_created_item_will_have_given_instance_id(self):
+        item = SiteConfigurationWithExplicitlyGivenId.get_solo()
+        self.assertEquals(item.pk, SiteConfigurationWithExplicitlyGivenId.singleton_instance_id)


### PR DESCRIPTION
Added support for configuring the pk value of the singleton instance. This is useful when you don't want the row in database for the singleton model to have pk equal to `1`. Current implementation in django-solo has the pk hardcoded to 1 in several places.