### PR TITLE
Fixed RemovedInDjango20Warning deprecation

### DIFF
--- a/solo/templatetags/solo_tags.py
+++ b/solo/templatetags/solo_tags.py
@@ -13,7 +13,7 @@ except ImportError:
 register = template.Library()
 
 
-@register.assignment_tag(name=solo_settings.GET_SOLO_TEMPLATE_TAG_NAME)
+@register.simple_tag(name=solo_settings.GET_SOLO_TEMPLATE_TAG_NAME)
 def get_solo(model_path):
     try:
         app_label, model_name = model_path.rsplit('.', 1)


### PR DESCRIPTION
I was getting this warning when using python 2.7 and django 1.11:

```
.../python2.7/site-packages/solo/templatetags/solo_tags.py:16: RemovedInDjango20Warning: assignment_tag() is deprecated. Use simple_tag() instead

    @register.assignment_tag(name=solo_settings.GET_SOLO_TEMPLATE_TAG_NAME)
```

I changed it to 'simple_tag', and everything seems to be working just the same :)