### PR TITLE
Retrieve app_label from opts in template context

### DIFF
--- a/solo/templates/admin/solo/change_form.html
+++ b/solo/templates/admin/solo/change_form.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
-    <a href="../">{{ app_label|capfirst|escape }}</a> &rsaquo; 
+    <a href="../">{{ opts.app_label|capfirst|escape }}</a> &rsaquo; 
     {{ opts.verbose_name|capfirst }}
 </div>
 {% endblock %}

--- a/solo/templates/admin/solo/object_history.html
+++ b/solo/templates/admin/solo/object_history.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
-<a href="../../">{{ app_label|capfirst|escape }}</a> &rsaquo; 
+<a href="../../">{{ opts.app_label|capfirst|escape }}</a> &rsaquo; 
 <a href="../">{{ object|truncatewords:"18" }}</a> &rsaquo; 
 {% trans 'History' %}
 


### PR DESCRIPTION
**Problem**
When using Django 1.11.5, I encountered a broken breadcrumb, which resulted in the app name not showing up:

![Screenshot from 2017-09-09 16-03-51](https://user-images.githubusercontent.com/5622927/30240870-d49b0b4c-9578-11e7-8f4b-ee5da2b02298.png)

After some research, I found out the `app_label` variable referenced in both templates seems to be unavailable.

**Proposed solution**
Since Django 1.7 the `app_label` variable is [no longer available](https://github.com/django/django/commit/ba60fcbcf7645afd82f3135ecb56562f8a9c9824#diff-3303a5aef1e8d39f3f17e3e3d337e4f3L74) in globally available admin actions in template context and should be retrieved as `opts.app_label`.

This can already be done in Django 1.6, as the [`opts` variable](https://github.com/django/django/blob/stable/1.6.x/django/contrib/admin/actions.py#L72) is present in the context. Therefore this change is backwards compatible.