### PR TITLE
Change the app_label to app verbose_name

### DIFF
--- a/solo/templates/admin/solo/change_form.html
+++ b/solo/templates/admin/solo/change_form.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
-    <a href="../">{{ opts.app_label|capfirst|escape }}</a> &rsaquo; 
+    <a href="../">{{ opts.app_config.verbose_name }}</a> &rsaquo; 
     {{ opts.verbose_name|capfirst }}
 </div>
 {% endblock %}

--- a/solo/templates/admin/solo/object_history.html
+++ b/solo/templates/admin/solo/object_history.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
-<a href="../../">{{ opts.app_label|capfirst|escape }}</a> &rsaquo; 
+<a href="../../">{{ opts.app_config.verbose_name }}</a> &rsaquo; 
 <a href="../">{{ object|truncatewords:"18" }}</a> &rsaquo; 
 {% trans 'History' %}
 


### PR DESCRIPTION
Can we use the app **verbose_name** (apps.py) in the change_form and object_history templates, instead of **app_label**? I think it would fit better with the standard Django-admin:

https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/change_form.html
https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/object_history.html

Not a problem if verbose_name is omitted in the apps.py file, since Django-admin will render exactly what is currently displayed: opts.app_label|capfirst|escape.