### PR TITLE
Set the zip_safe option to False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
     author='lazybird',
     long_description=long_description,
     include_package_data=True,
+    zip_safe=False,
     license='Creative Commons Attribution 3.0 Unported',
 )


### PR DESCRIPTION
Otherwise, the egg file is not unzipped and the templates cannot be loaded.

See #81 

Thanks @lazybird !