### PR TITLE
Add a flag to allow disabling the admin list page being skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ GET_SOLO_TEMPLATE_TAG_NAME = 'get_config'
 
 ### Admin override flag
 
-By default, the admin is overrided. But if you wih to keep the object list
+By default, the admin is overridden. But if you wih to keep the object list
 page (e.g. to customize actions), you can set the `SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE`
 to `False`.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Django Solo provides a modified admin for that.
   intermediary object list page.
 * From the edit page, we cannot delete the object (4) nor can we add a new one (5).
 
+If you wish to disable the skipping of the object list page, and have the default
+breadcrumbs, you should set `SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE` to `False` in your settings.
 
 Availability from templates
 ---------------------------
@@ -195,6 +197,16 @@ You can change the name `get_solo` using the
 
 ```python
 GET_SOLO_TEMPLATE_TAG_NAME = 'get_config'
+```
+
+### Admin override flag
+
+By default, the admin is overrided. But if you wih to keep the object list
+page (e.g. to customize actions), you can set the `SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE`
+to `False`.
+
+```python
+SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE = True
 ```
 
 ### Cache backend

--- a/solo/settings.py
+++ b/solo/settings.py
@@ -1,7 +1,11 @@
 from django.conf import settings
 
+# template parameters
 GET_SOLO_TEMPLATE_TAG_NAME = getattr(settings,
     'GET_SOLO_TEMPLATE_TAG_NAME', 'get_solo')
+
+SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE = getattr(settings,
+    'SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE', True)
 
 # The cache that should be used, e.g. 'default'. Refers to Django CACHES setting.
 # Set to None to disable caching.

--- a/solo/templates/admin/solo/change_form.html
+++ b/solo/templates/admin/solo/change_form.html
@@ -3,14 +3,20 @@
 {% load admin_urls %}
 
 {% block breadcrumbs %}
+{% if skip_object_list_page %}
 <div class="breadcrumbs">
-    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
-    <a href="../">{{ opts.app_config.verbose_name }}</a> &rsaquo; 
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo;
+    <a href="../">{{ opts.app_config.verbose_name }}</a> &rsaquo;
     {{ opts.verbose_name|capfirst }}
 </div>
+{% else %}
+{{ block.super }}
+{% endif %}
 {% endblock %}
 
 {% block object-tools-items %}
-<li><a href="{% url opts|admin_urlname:'history' %}" class="historylink">{% trans "History" %}</a></li>
-{% if has_absolute_url %}<li><a href="{% url 'admin:view_on_site' content_type_id original.pk %}" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif%}
+<li><a href="{% url opts|admin_urlname:'history' original.pk %}" class="historylink">{% trans "History" %}</a></li>
+{% if has_absolute_url %}
+<li><a href="{% url 'admin:view_on_site' content_type_id original.pk %}" class="viewsitelink">{% trans "View on site" %}</a></li>
+{% endif %}
 {% endblock %}

--- a/solo/templates/admin/solo/object_history.html
+++ b/solo/templates/admin/solo/object_history.html
@@ -2,13 +2,14 @@
 {% load i18n %}
 
 {% block breadcrumbs %}
+{% if skip_object_list_page %}
 <div class="breadcrumbs">
-<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo; 
-<a href="../../">{{ opts.app_config.verbose_name }}</a> &rsaquo; 
-<a href="../">{{ object|truncatewords:"18" }}</a> &rsaquo; 
-{% trans 'History' %}
-
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a> &rsaquo;
+    <a href="../../">{{ opts.app_config.verbose_name }}</a> &rsaquo;
+    <a href="../">{{ object|truncatewords:"18" }}</a> &rsaquo;
+    {% trans 'History' %}
 </div>
+{% else %}
+{{ block.super }}
+{% endif %}
 {% endblock %}
-
-


### PR DESCRIPTION
In some cases (e.g. https://github.com/lazybird/django-solo/issues/62) we want to have access to the model's object list page in the admin, to set up custom actions for exemple.

This PR adds a settings flag, `SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE`, that defaults to `False`. If set to `True`, the object list page will not be skipped, and the breadcrumbs in the change_view & history_view won't be overridden.

Todo : 
- add tests ?