### PR TITLE
Changing 'django.conf.urls.url()' to 'django.urls.re_path()' because of deprecation

### DIFF
--- a/solo/admin.py
+++ b/solo/admin.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 from django.http import HttpResponseRedirect
 
@@ -8,7 +8,7 @@ from solo import settings as solo_settings
 try:
     from django.utils.encoding import force_unicode
 except ImportError:
-    from django.utils.encoding import force_text as force_unicode 
+    from django.utils.encoding import force_text as force_unicode
 from django.utils.translation import ugettext as _
 
 
@@ -41,23 +41,25 @@ class SingletonModelAdmin(admin.ModelAdmin):
             'model_name': model_name,
         }
         custom_urls = [
-            url(r'^history/$',
-                self.admin_site.admin_view(self.history_view),
-                {'object_id': str(self.singleton_instance_id)},
-                name='%s_history' % url_name_prefix),
-            url(r'^$',
-                self.admin_site.admin_view(self.change_view),
-                {'object_id': str(self.singleton_instance_id)},
-                name='%s_change' % url_name_prefix),
+            re_path(r'^history/$',
+                    self.admin_site.admin_view(self.history_view),
+                    {'object_id': str(self.singleton_instance_id)},
+                    name='%s_history' % url_name_prefix),
+            re_path(r'^$',
+                    self.admin_site.admin_view(self.change_view),
+                    {'object_id': str(self.singleton_instance_id)},
+                    name='%s_change' % url_name_prefix),
         ]
 
         # By inserting the custom URLs first, we overwrite the standard URLs.
         return custom_urls + urls
 
     def response_change(self, request, obj):
-        msg = _('%(obj)s was changed successfully.') % {'obj': force_unicode(obj)}
+        msg = _('%(obj)s was changed successfully.') % {
+            'obj': force_unicode(obj)}
         if '_continue' in request.POST:
-            self.message_user(request, msg + ' ' + _('You may edit it again below.'))
+            self.message_user(request, msg + ' ' +
+                              _('You may edit it again below.'))
             return HttpResponseRedirect(request.path)
         else:
             self.message_user(request, msg)
@@ -66,7 +68,7 @@ class SingletonModelAdmin(admin.ModelAdmin):
     def change_view(self, request, object_id, form_url='', extra_context=None):
         if object_id == str(self.singleton_instance_id):
             self.model.objects.get_or_create(pk=self.singleton_instance_id)
-        
+
         if not extra_context:
             extra_context = dict()
         extra_context['skip_object_list_page'] = solo_settings.SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE


### PR DESCRIPTION
Hi 😄 ,

There is a deprecation error for using 'django.conf.urls.url()'. It has been replaced with ''django.urls.re_path()'. For more info, have a look to the [documentation](https://docs.djangoproject.com/en/3.1/ref/urls/#url).

Thanks!