### PR TITLE
Separate access of singleton from admin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ from solo.admin import SingletonModelAdmin
 from config.models import SiteConfiguration
 
 admin.site.register(SiteConfiguration, SingletonModelAdmin)
+```
 
+```python
 # There is only one item in the table, you can get it this way:
 from .models import SiteConfiguration
 config = SiteConfiguration.objects.get()


### PR DESCRIPTION
Make it more clear that you don't need to access the singleton in the `admin.py` global scope. This causes issues with database access at import time and may confuse new users.