### PR TITLE
RemovedInDjango41Warning: 'solo' defines default_app_config = 'solo.apps.SoloAppConfig'. Django now detects this configuration automatically. You can remove default_app_config.

### DIFF
--- a/solo/__init__.py
+++ b/solo/__init__.py
@@ -1,7 +1,10 @@
 """django-solo helps working with singletons: things like global settings that you want to edit from the admin site.
 """
+import django
+
 
 __version__ = '1.1.5'
 __doc__ = 'Django Solo helps working with singletons'
 
-default_app_config = 'solo.apps.SoloAppConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'solo.apps.SoloAppConfig'


### PR DESCRIPTION
RemovedInDjango41Warning: 'solo' defines default_app_config = 'solo.apps.SoloAppConfig'. Django now detects this configuration automatically. You can remove default_app_config.