### PR TITLE
Refactor code to support django >=3.2

### DIFF
--- a/examples/config/models.py
+++ b/examples/config/models.py
@@ -7,7 +7,7 @@ class SiteConfiguration(SingletonModel):
     site_name = models.CharField(max_length=255, default='Site Name')
     maintenance_mode = models.BooleanField(default=False)
 
-    def __unicode__(self):
+    def __str__(self):
         return u"Site Configuration"
 
     class Meta:

--- a/solo/settings.py
+++ b/solo/settings.py
@@ -14,3 +14,4 @@ SOLO_CACHE = None
 SOLO_CACHE_TIMEOUT = 60*5
 
 SOLO_CACHE_PREFIX = 'solo'
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/solo/tests/models.py
+++ b/solo/tests/models.py
@@ -8,7 +8,7 @@ class SiteConfiguration(SingletonModel):
     site_name = models.CharField(max_length=255, default='Default Config')
     file = models.FileField(upload_to='files', default=SimpleUploadedFile("default-file.pdf", None))
 
-    def __unicode__(self):
+    def __str__(self):
         return "Site Configuration"
 
     class Meta:
@@ -19,7 +19,7 @@ class SiteConfigurationWithExplicitlyGivenId(SingletonModel):
     singleton_instance_id = 24
     site_name = models.CharField(max_length=255, default='Default Config')
 
-    def __unicode__(self):
+    def __str__(self):
         return "Site Configuration"
 
     class Meta:


### PR DESCRIPTION
Changes made: 

- Replace uncode with str, please refer to [this](https://docs.djangoproject.com/en/1.10/topics/python3/#str-and-unicode-methods) in Django Doc

- Excplicity set defualt autofield to be `AutoField`: please refer to [this](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys) in Django Doc, 
> To avoid unwanted migrations in the future, either explicitly set DEFAULT_AUTO_FIELD to AutoField:

This PR relates to #96 and edx/upgrades/issues/78
