### PR TITLE
Set default model for test settings

### DIFF
--- a/solo/tests/settings.py
+++ b/solo/tests/settings.py
@@ -36,3 +36,4 @@ TEMPLATES = [
         'APP_DIRS': True,
     },
 ]
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
Just adding/setting the default field in test setting, to avoid warning in Django3.2 
`DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'` 
Simliar to 8849f14cd6025886c3fc5be6a0f91aee17b47b63 