### PR TITLE
Fix django 4.0 features that are broken.

### DIFF
--- a/solo/admin.py
+++ b/solo/admin.py
@@ -8,8 +8,14 @@ from solo import settings as solo_settings
 try:
     from django.utils.encoding import force_unicode
 except ImportError:
-    from django.utils.encoding import force_text as force_unicode
-from django.utils.translation import ugettext as _
+    try:
+        from django.utils.encoding import force_text as force_unicode
+    except:
+        from django.utils.encoding import force_str as force_unicode
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
 
 
 class SingletonModelAdmin(admin.ModelAdmin):

--- a/solo/templatetags/solo_tags.py
+++ b/solo/templatetags/solo_tags.py
@@ -1,6 +1,8 @@
 from django import template
-from django.utils.translation import ugettext as _
-
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
 from solo import settings as solo_settings
 
 try:


### PR DESCRIPTION
I saw another PR that fixes some of these that has not merged yet. Just adding everything into a single PR.

Note that ugettext is an alias for gettext after Django 2.0 (according to comments for ugettext in django 3.0)

In django 4.0 ugettext is removed.