### PR TITLE
SingletonModelAdmin ==> self.__class__; gettext ==> gettext_lazy

### DIFF
--- a/solo/admin.py
+++ b/solo/admin.py
@@ -26,7 +26,7 @@ class SingletonModelAdmin(admin.ModelAdmin):
         # _meta.model_name only exists on Django>=1.6 -
         # on earlier versions, use module_name.lower()
         try:
-            model_name = gettext_lazy.model._meta.model_name
+            model_name = self.model._meta.model_name
         except AttributeError:
             model_name = self.model._meta.module_name.lower()
 


### PR DESCRIPTION
don't rely on a direct class name

In definitions like forms or models you should use gettext_lazy because the code of this definitions is only executed once (mostly on django's startup); gettext_lazy translates the strings in a lazy fashion, which means, eg. every time you access the name of an attribute on a model the string will be newly translated-which totally makes sense because you might be looking at this model in different languages since django was started!