### PR TITLE
Add typing support to `get_solo`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Unreleased
+==========
+
+* Add typing support
+
 django-solo-2.2.0
 =================
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
 * Add typing support
+* Deprecate `solo.models.get_cache`
 
 django-solo-2.2.0
 =================

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.md
 include LICENSE
 include CHANGES
+include solo/py.typed
 recursive-include solo/templates *
 recursive-include solo/locale *.mo *.po

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.mypy]
+ignore_missing_imports = true
+strict = true
+exclude = "solo/tests"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,10 @@ setup(
     version=version,
     description='Django Solo helps working with singletons',
     python_requires='>=3.8',
-    install_requires=['django>=3.2'],
+    install_requires=[
+        'django>=3.2',
+        'typing-extensions>=4.0.1; python_version < "3.11"',
+    ],
     packages=find_packages(),
     url='https://github.com/lazybird/django-solo/',
     author='lazybird',

--- a/solo/models.py
+++ b/solo/models.py
@@ -26,7 +26,7 @@ def get_cache(cache_name: str) -> BaseCache:
         DeprecationWarning,
         stacklevel=2,
     )
-    return caches[cache_name]
+    return caches[cache_name]  # type: ignore[no-any-return]  # mypy bug, unable to get a MRE
 
 
 class SingletonModel(models.Model):

--- a/solo/models.py
+++ b/solo/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, TypeVar
+import sys
+from typing import Any
 
 from django.conf import settings
 from django.core.cache import caches
@@ -8,9 +9,13 @@ from django.db import models
 
 from solo import settings as solo_settings
 
-DEFAULT_SINGLETON_INSTANCE_ID = 1
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
-Self = TypeVar("Self", bound="SingletonModel")
+
+DEFAULT_SINGLETON_INSTANCE_ID = 1
 
 
 class SingletonModel(models.Model):
@@ -51,7 +56,7 @@ class SingletonModel(models.Model):
         return '%s:%s' % (prefix, cls.__name__.lower())
 
     @classmethod
-    def get_solo(cls: type[Self]) -> Self:
+    def get_solo(cls) -> Self:
         cache_name = getattr(settings, 'SOLO_CACHE', solo_settings.SOLO_CACHE)
         if not cache_name:
             obj, _ = cls.objects.get_or_create(pk=cls.singleton_instance_id)

--- a/solo/models.py
+++ b/solo/models.py
@@ -22,7 +22,7 @@ DEFAULT_SINGLETON_INSTANCE_ID = 1
 def get_cache(cache_name: str) -> BaseCache:
     warnings.warn(
         DeprecationWarning,
-        "'get_cache' is deprecated and will be removed in django-solo 2.3.0. "
+        "'get_cache' is deprecated and will be removed in django-solo 2.4.0. "
         "Instead, use 'caches' from 'django.core.cache'.",
         stacklevel=2,
     )

--- a/solo/models.py
+++ b/solo/models.py
@@ -1,3 +1,5 @@
+from typing import Type, TypeVar
+
 from django.conf import settings
 from django.db import models
 
@@ -10,6 +12,9 @@ except ImportError:
 from solo import settings as solo_settings
 
 DEFAULT_SINGLETON_INSTANCE_ID = 1
+
+Self = TypeVar("Self", bound="SingletonModel")
+
 
 class SingletonModel(models.Model):
     singleton_instance_id = DEFAULT_SINGLETON_INSTANCE_ID
@@ -49,7 +54,7 @@ class SingletonModel(models.Model):
         return '%s:%s' % (prefix, cls.__name__.lower())
 
     @classmethod
-    def get_solo(cls):
+    def get_solo(cls: Type[Self]) -> Self:
         cache_name = getattr(settings, 'SOLO_CACHE', solo_settings.SOLO_CACHE)
         if not cache_name:
             obj, created = cls.objects.get_or_create(pk=cls.singleton_instance_id)

--- a/solo/models.py
+++ b/solo/models.py
@@ -21,9 +21,9 @@ DEFAULT_SINGLETON_INSTANCE_ID = 1
 
 def get_cache(cache_name: str) -> BaseCache:
     warnings.warn(
-        DeprecationWarning,
         "'get_cache' is deprecated and will be removed in django-solo 2.4.0. "
         "Instead, use 'caches' from 'django.core.cache'.",
+        DeprecationWarning,
         stacklevel=2,
     )
     return caches[cache_name]

--- a/solo/models.py
+++ b/solo/models.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from typing import Any
 
 from django.conf import settings
-from django.core.cache import caches
+from django.core.cache import BaseCache, caches
 from django.db import models
 
 from solo import settings as solo_settings
@@ -16,6 +17,16 @@ else:
 
 
 DEFAULT_SINGLETON_INSTANCE_ID = 1
+
+
+def get_cache(cache_name: str) -> BaseCache:
+    warnings.warn(
+        DeprecationWarning,
+        "'get_cache' is deprecated and will be removed in django-solo 2.3.0. "
+        "Instead, use 'caches' from 'django.core.cache'.",
+        stacklevel=2,
+    )
+    return caches[cache_name]
 
 
 class SingletonModel(models.Model):

--- a/solo/settings.py
+++ b/solo/settings.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 from django.conf import settings
 
 # template parameters
-GET_SOLO_TEMPLATE_TAG_NAME = getattr(settings,
-    'GET_SOLO_TEMPLATE_TAG_NAME', 'get_solo')
+GET_SOLO_TEMPLATE_TAG_NAME: str = getattr(
+    settings, 'GET_SOLO_TEMPLATE_TAG_NAME', 'get_solo'
+)
 
-SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE = getattr(settings,
-    'SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE', True)
+SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE: bool = getattr(
+    settings, 'SOLO_ADMIN_SKIP_OBJECT_LIST_PAGE', True
+)
 
 # The cache that should be used, e.g. 'default'. Refers to Django CACHES setting.
 # Set to None to disable caching.
-SOLO_CACHE = None
+SOLO_CACHE: str | None = None
 
-SOLO_CACHE_TIMEOUT = 60*5
+SOLO_CACHE_TIMEOUT = 60 * 5
 
 SOLO_CACHE_PREFIX = 'solo'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/solo/templatetags/solo_tags.py
+++ b/solo/templatetags/solo_tags.py
@@ -1,20 +1,15 @@
 from django import template
+from django.apps import apps
 from django.utils.translation import gettext as _
 
 from solo import settings as solo_settings
-
-try:
-    from django.apps import apps
-    get_model = apps.get_model
-except ImportError:
-    from django.db.models.loading import get_model
-
+from solo.models import SingletonModel
 
 register = template.Library()
 
 
 @register.simple_tag(name=solo_settings.GET_SOLO_TEMPLATE_TAG_NAME)
-def get_solo(model_path):
+def get_solo(model_path: str) -> SingletonModel:
     try:
         app_label, model_name = model_path.rsplit('.', 1)
     except ValueError:
@@ -22,7 +17,7 @@ def get_solo(model_path):
             "Templatetag requires the model dotted path: 'app_label.ModelName'. "
             "Received '%s'." % model_path
         ))
-    model_class = get_model(app_label, model_name)
+    model_class: type[SingletonModel] = apps.get_model(app_label, model_name)
     if not model_class:
         raise template.TemplateSyntaxError(_(
             "Could not get the model name '%(model)s' from the application "

--- a/solo/tests/tests.py
+++ b/solo/tests/tests.py
@@ -1,9 +1,9 @@
+from django.core.cache import caches
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template import Template, Context
 from django.test import TestCase
 
 from django.test.utils import override_settings
-from solo.models import get_cache
 from solo.tests.models import SiteConfiguration, SiteConfigurationWithExplicitlyGivenId
 
 
@@ -16,7 +16,7 @@ class SingletonTest(TestCase):
             '{{ site_config.site_name }}'
             '{{ site_config.file.url }}'
         )
-        self.cache = get_cache('default')
+        self.cache = caches['default']
         self.cache_key = SiteConfiguration.get_cache_key()
         self.cache.clear()
         SiteConfiguration.objects.all().delete()

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
 [testenv:type-check]
 skip_install = true
 deps =
-    mypy
-    django-stubs
+    mypy==1.8.0
+    django-stubs==4.2.7
 commands =
     mypy solo

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,13 @@
 python =
     3.8: py38-django{32,42}
     3.9: py39-django{32,42}
-    3.10: py310-django{32,42,50}
+    3.10: py310-django{32,42,50}, type-check
     3.11: py311-django{42,50}
     3.12: py312-django{42,50}
 
 [tox]
 envlist =
+    type-check
     py{38,39,310}-django{32,42}
     py{311,312}-django{42,50}
 
@@ -33,3 +34,11 @@ deps =
     twine
 commands =
     {envpython} -m twine upload {toxinidir}/dist/*
+
+[testenv:type-check]
+skip_install = true
+deps =
+    mypy
+    django-stubs
+commands =
+    mypy solo


### PR DESCRIPTION
As `get_solo` hits the cache, type checkers can't infer the return type of the method correctly. User could use `typing.cast` or similar but having it fixed in the library directly sounds easier. `typing.TypeVar` is used as a workaround until `typing.Self` can be used without making use of `typing_extensions`.