### PR TITLE
Support Django 5.0 and drop EOL Django 4.0 and 4.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Unreleased
 * Add support for Python 3.12
 * Drop support for Python 3.7
 * Add support for Django 5.0
+* Drop support for end of life Django 4.0 and 4.1
 
 django-solo-2.1.0
 =================

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Unreleased
 
 * Add support for Python 3.12
 * Drop support for Python 3.7
+* Add support for Django 5.0
 
 django-solo-2.1.0
 =================

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ setup(
     license='Creative Commons Attribution 3.0 Unported',
     classifiers=[
         'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
-        'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,20 @@
 # Configure which test environments are run for each Github Actions Python version.
 [gh-actions]
 python =
-    3.8: py38-django{32,40,41,42}
-    3.9: py39-django{32,40,41,42}
-    3.10: py310-django{32,40,41,42,50}
-    3.11: py311-django{40,41,42,50}
-    3.12: py312-django{40,41,42,50}
+    3.8: py38-django{32,42}
+    3.9: py39-django{32,42}
+    3.10: py310-django{32,42,50}
+    3.11: py311-django{42,50}
+    3.12: py312-django{42,50}
 
 [tox]
 envlist =
-    py{38,39,310}-django{32,40,41,42}
-    py{311,312}-django{40,41,42,50}
+    py{38,39,310}-django{32,42}
+    py{311,312}-django{42,50}
 
 [testenv]
 deps =
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,14 @@
 python =
     3.8: py38-django{32,40,41,42}
     3.9: py39-django{32,40,41,42}
-    3.10: py310-django{32,40,41,42}
-    3.11: py311-django{40,41,42}
-    3.12: py312-django{40,41,42}
+    3.10: py310-django{32,40,41,42,50}
+    3.11: py311-django{40,41,42,50}
+    3.12: py312-django{40,41,42,50}
 
 [tox]
 envlist =
     py{38,39,310}-django{32,40,41,42}
-    py{311,312}-django{40,41,42}
+    py{311,312}-django{40,41,42,50}
 
 [testenv]
 deps =
@@ -18,6 +18,7 @@ deps =
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
 commands =
     {envpython} {toxinidir}/manage.py test solo --settings=solo.tests.settings
 


### PR DESCRIPTION
- Support Django 5.0
- Drop support for end of life Django 4.0 and 4.1