### PR TITLE
Disambiguate cache key for similarly named models

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+* Fix similarly named models from different apps having the same cache key
+
 django-solo-2.3.0
 =================
 

--- a/solo/models.py
+++ b/solo/models.py
@@ -64,7 +64,7 @@ class SingletonModel(models.Model):
     @classmethod
     def get_cache_key(cls) -> str:
         prefix = getattr(settings, "SOLO_CACHE_PREFIX", solo_settings.SOLO_CACHE_PREFIX)
-        return f"{prefix}:{cls.__name__.lower()}"
+        return f"{prefix}:{cls.__module__.lower()}:{cls.__name__.lower()}"
 
     @classmethod
     def get_solo(cls) -> Self:

--- a/solo/models.py
+++ b/solo/models.py
@@ -64,6 +64,8 @@ class SingletonModel(models.Model):
     @classmethod
     def get_cache_key(cls) -> str:
         prefix = getattr(settings, "SOLO_CACHE_PREFIX", solo_settings.SOLO_CACHE_PREFIX)
+        # Include the model's module in the cache key so similarly named models from different
+        # apps do not have the same cache key.
         return f"{prefix}:{cls.__module__.lower()}:{cls.__name__.lower()}"
 
     @classmethod

--- a/solo/tests/settings.py
+++ b/solo/tests/settings.py
@@ -17,6 +17,7 @@ DATABASES = {
 INSTALLED_APPS = (
     "solo",
     "solo.tests",
+    "solo.tests.testapp2",
 )
 
 SECRET_KEY = "any-key"

--- a/solo/tests/testapp2/models.py
+++ b/solo/tests/testapp2/models.py
@@ -1,0 +1,6 @@
+from solo.models import SingletonModel
+
+
+class SiteConfiguration(SingletonModel):
+    class Meta:
+        verbose_name = "Site Configuration 2"

--- a/solo/tests/tests.py
+++ b/solo/tests/tests.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from solo.tests.models import SiteConfiguration, SiteConfigurationWithExplicitlyGivenId
+from solo.tests.testapp2.models import SiteConfiguration as SiteConfiguration2
 
 
 class SingletonTest(TestCase):
@@ -103,3 +104,11 @@ class SingletonWithExplicitIdTest(TestCase):
     def test_when_singleton_instance_id_is_given_created_item_will_have_given_instance_id(self):
         item = SiteConfigurationWithExplicitlyGivenId.get_solo()
         self.assertEqual(item.pk, SiteConfigurationWithExplicitlyGivenId.singleton_instance_id)
+
+
+class SingletonsWithAmbiguousNameTest(TestCase):
+    def test_cache_key_is_not_ambiguous(self):
+        assert SiteConfiguration.get_cache_key() != SiteConfiguration2.get_cache_key()
+
+    def test_get_solo_returns_the_correct_singleton(self):
+        assert SiteConfiguration.get_solo() != SiteConfiguration2.get_solo()


### PR DESCRIPTION
Two models with the same name in different apps would previously get the same cache key.
Including the model's module in the cache key fixes this.