### PR TITLE
Update supported Python and Django versions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,10 @@ Unreleased
 ==========
 
 * Fix similarly named models from different apps having the same cache key
+* Drop support for Python 3.8
+* Add support for Python 3.13
+* Drop support for end of life Django 3.2
+* Add support for Django 5.1
 
 django-solo-2.3.0
 =================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,23 +10,23 @@ maintainers = [
     {name = "John Hagen", email = "johnthagen@gmail.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "django>=3.2",
+    "django>=4.2",
     "typing-extensions>=4.0.1; python_version < '3.11'",
 ]
 license = {text = "Creative Commons Attribution 3.0 Unported"}
@@ -47,7 +47,7 @@ exclude = "solo/tests"
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = [

--- a/solo/models.py
+++ b/solo/models.py
@@ -26,7 +26,7 @@ def get_cache(cache_name: str) -> BaseCache:
         DeprecationWarning,
         stacklevel=2,
     )
-    return caches[cache_name]  # type: ignore[no-any-return]  # mypy bug, unable to get a MRE
+    return caches[cache_name]
 
 
 class SingletonModel(models.Model):
@@ -73,11 +73,11 @@ class SingletonModel(models.Model):
         cache_name = getattr(settings, "SOLO_CACHE", solo_settings.SOLO_CACHE)
         if not cache_name:
             obj, _ = cls.objects.get_or_create(pk=cls.singleton_instance_id)
-            return obj  # type: ignore[return-value]
+            return obj
         cache = caches[cache_name]
         cache_key = cls.get_cache_key()
         obj = cache.get(cache_key)
         if not obj:
             obj, _ = cls.objects.get_or_create(pk=cls.singleton_instance_id)
             obj.set_to_cache()
-        return obj  # type: ignore[return-value]
+        return obj

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,24 @@
 # Configure which test environments are run for each Github Actions Python version.
 [gh-actions]
 python =
-    3.8: py38-django{32,42}
-    3.9: py39-django{32,42}
-    3.10: py310-django{32,42,50}, type-check, lint
-    3.11: py311-django{42,50}
-    3.12: py312-django{42,50}
+    3.9: py39-django{42}
+    3.10: py310-django{42,50}, type-check, lint
+    3.11: py311-django{42,50,51}
+    3.12: py312-django{42,50,51}
+    3.13: py312-django{42,50,51}
 
 [tox]
 envlist =
     type-check
     lint
-    py{38,39,310}-django{32,42}
-    py{311,312}-django{42,50}
+    py{38,39,310}-django{42,50}
+    py{311,312,313}-django{42,50,51}
 
 [testenv]
 deps =
-    django32: Django>=3.2,<4.0
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
 commands =
     {envpython} {toxinidir}/manage.py test solo --settings=solo.tests.settings
 
@@ -39,15 +39,15 @@ commands =
 [testenv:type-check]
 skip_install = true
 deps =
-    mypy==1.8.0
-    django-stubs==4.2.7
+    mypy==1.12.0
+    django-stubs==5.1.0
 commands =
     mypy solo
 
 [testenv:lint]
 skip_install = true
 deps =
-    ruff==0.5.0
+    ruff==0.7.0
 commands =
     ruff format --check
     ruff check

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ python =
     3.10: py310-django{42,50}, type-check, lint
     3.11: py311-django{42,50,51}
     3.12: py312-django{42,50,51}
-    3.13: py312-django{42,50,51}
+    3.13: py313-django{42,50,51}
 
 [tox]
 envlist =


### PR DESCRIPTION
* Drop support for Python 3.8
* Add support for Python 3.13
* Drop support for end of life Django 3.2
* Add support for Django 5.1
* Update type check and lint dependencies