### PR TITLE
Simplify default_app_config after dropping support for Django <3.2

### DIFF
--- a/solo/__init__.py
+++ b/solo/__init__.py
@@ -3,8 +3,6 @@ django-solo helps working with singletons:
 things like global settings that you want to edit from the admin site.
 """
 
-import django
-
 __version__ = "2.3.0"
 
 default_app_config = "solo.apps.SoloAppConfig"

--- a/solo/__init__.py
+++ b/solo/__init__.py
@@ -4,5 +4,3 @@ things like global settings that you want to edit from the admin site.
 """
 
 __version__ = "2.3.0"
-
-default_app_config = "solo.apps.SoloAppConfig"

--- a/solo/__init__.py
+++ b/solo/__init__.py
@@ -7,5 +7,4 @@ import django
 
 __version__ = "2.3.0"
 
-if django.VERSION < (3, 2):
-    default_app_config = "solo.apps.SoloAppConfig"
+default_app_config = "solo.apps.SoloAppConfig"


### PR DESCRIPTION
Django 3.2+ will auto-discover the `AppConfig`

- https://docs.djangoproject.com/en/5.1/releases/3.2/#automatic-appconfig-discovery