### PR TITLE
Fix cache poisoning when a singleton write is rolled back

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+Unreleased
+==========
+
+* Fix cache poisoning when a singleton is saved, deleted, or read on a cache miss
+  inside a transaction that is later rolled back. Cache updates from ``save()``,
+  ``delete()`` and ``get_solo()`` are now deferred until the surrounding
+  transaction commits (via ``transaction.on_commit``), so a rollback no longer
+  leaves the cache disagreeing with the database. In autocommit mode the callbacks
+  fire immediately, so non-transactional behaviour is unchanged.
+
 django-solo-2.5.1
 =================
 

--- a/solo/models.py
+++ b/solo/models.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from django.conf import settings
 from django.core.cache import BaseCache, caches
-from django.db import models
+from django.db import models, transaction
 
 from solo import settings as solo_settings
 
@@ -38,10 +38,14 @@ class SingletonModel(models.Model):
     def save(self, *args: Any, **kwargs: Any) -> None:
         self.pk = self.singleton_instance_id
         super().save(*args, **kwargs)
-        self.set_to_cache()
+        # Defer until commit so a rollback can't poison the cache (fires
+        # immediately in autocommit mode).
+        transaction.on_commit(self.set_to_cache)
 
     def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
-        self.clear_cache()
+        # Defer until commit so a rollback can't poison the cache (fires
+        # immediately in autocommit mode).
+        transaction.on_commit(self.clear_cache)
         return super().delete(*args, **kwargs)
 
     @classmethod
@@ -79,5 +83,8 @@ class SingletonModel(models.Model):
         obj = cache.get(cache_key)
         if not obj:
             obj, _ = cls.objects.get_or_create(pk=cls.singleton_instance_id)
-            obj.set_to_cache()
+            # Defer until commit so a rollback (e.g. of a row created here, or of
+            # an uncommitted change we just read) can't poison the cache (fires
+            # immediately in autocommit mode).
+            transaction.on_commit(obj.set_to_cache)
         return obj

--- a/solo/tests/tests.py
+++ b/solo/tests/tests.py
@@ -1,11 +1,16 @@
 from django.core.cache import caches
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import transaction
 from django.template import Context, Template, TemplateSyntaxError
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
 
 from solo.tests.models import SiteConfiguration, SiteConfigurationWithExplicitlyGivenId
 from solo.tests.testapp2.models import SiteConfiguration as SiteConfiguration2
+
+
+class _RollbackError(Exception):
+    """Raised inside ``atomic()`` to force a rollback in the tests below."""
 
 
 class SingletonTest(TestCase):
@@ -73,11 +78,16 @@ class SingletonTest(TestCase):
 
         one_cfg = SiteConfiguration.get_solo()
         one_cfg.site_name = "TEST SITE PLEASE IGNORE"
-        one_cfg.save()
+        # save() now updates the cache via transaction.on_commit, which does not
+        # fire inside the transaction TestCase wraps each test in, so capture and
+        # execute the on_commit callbacks to observe the cache update.
+        with self.captureOnCommitCallbacks(execute=True):
+            one_cfg.save()
         self.assertEqual(SiteConfiguration.objects.count(), 1)
         self.assertIsNotNone(self.cache.get(self.cache_key))
 
-        one_cfg.delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            one_cfg.delete()
         self.assertEqual(SiteConfiguration.objects.count(), 0)
         self.assertIsNone(self.cache.get(self.cache_key))
         self.assertEqual(SiteConfiguration.get_solo().site_name, "Default Config")
@@ -132,3 +142,104 @@ class SingletonsWithAmbiguousNameTest(TestCase):
 
     def test_get_solo_returns_the_correct_singleton(self):
         assert SiteConfiguration.get_solo() != SiteConfiguration2.get_solo()
+
+
+@override_settings(SOLO_CACHE="default")
+class TransactionRollbackCacheTest(TransactionTestCase):
+    """Regression tests: a rollback of an outer transaction must not poison the cache.
+
+    These rely on ``transaction.on_commit`` callbacks actually firing on commit and
+    being discarded on rollback, so they use ``TransactionTestCase``. A plain
+    ``TestCase`` wraps every test in a transaction that never commits, which would
+    suppress the ``on_commit`` callbacks and make the ``save``/``delete`` fixes
+    look broken. The cache must be enabled (``SOLO_CACHE`` set) for any of this to
+    matter, as ``set_to_cache``/``clear_cache`` are no-ops otherwise.
+    """
+
+    def setUp(self):
+        self.cache = caches["default"]
+        self.cache_key = SiteConfiguration.get_cache_key()
+        # LocMemCache is process-global and not reset between tests.
+        self.cache.clear()
+        SiteConfiguration.objects.all().delete()
+
+    def test_save_in_rolled_back_transaction_does_not_poison_cache(self):
+        # Establish a committed value, present in both the DB and the cache.
+        cfg = SiteConfiguration.get_solo()
+        cfg.site_name = "Committed"
+        cfg.save()
+        self.assertEqual(self.cache.get(self.cache_key).site_name, "Committed")
+
+        # Save a new value inside a transaction that rolls back.
+        with self.assertRaises(_RollbackError), transaction.atomic():
+            cfg.site_name = "Rolled back"
+            cfg.save()
+            raise _RollbackError
+
+        # The DB reverted to the committed value...
+        self.assertEqual(SiteConfiguration.objects.get(pk=cfg.pk).site_name, "Committed")
+        # ...and the cache must not hold the rolled-back value.
+        self.assertEqual(self.cache.get(self.cache_key).site_name, "Committed")
+
+    def test_delete_in_rolled_back_transaction_does_not_poison_cache(self):
+        # Establish a committed value, present in both the DB and the cache.
+        cfg = SiteConfiguration.get_solo()
+        cfg.site_name = "Committed"
+        cfg.save()
+        self.assertEqual(self.cache.get(self.cache_key).site_name, "Committed")
+
+        # Delete inside a transaction that rolls back. Capture the pk first, as
+        # Model.delete() resets the in-memory instance's pk to None.
+        pk = cfg.pk
+        with self.assertRaises(_RollbackError), transaction.atomic():
+            cfg.delete()
+            raise _RollbackError
+
+        # The row still exists (the delete was rolled back)...
+        self.assertEqual(SiteConfiguration.objects.filter(pk=pk).count(), 1)
+        # ...and the cache must still hold the (not-actually-deleted) value.
+        cached = self.cache.get(self.cache_key)
+        self.assertIsNotNone(cached)
+        self.assertEqual(cached.site_name, "Committed")
+
+    def test_get_solo_create_on_miss_in_rolled_back_transaction_does_not_poison_cache(self):
+        # Start with no row and an empty cache.
+        self.assertEqual(SiteConfiguration.objects.count(), 0)
+        self.assertIsNone(self.cache.get(self.cache_key))
+
+        # A cache-miss read inside a transaction creates the row, then rolls back.
+        with self.assertRaises(_RollbackError), transaction.atomic():
+            obj = SiteConfiguration.get_solo()
+            self.assertEqual(obj.site_name, "Default Config")
+            raise _RollbackError
+
+        # The created row was rolled back...
+        self.assertEqual(SiteConfiguration.objects.count(), 0)
+        # ...and the cache must not hold an object for the row that no longer exists.
+        self.assertIsNone(self.cache.get(self.cache_key))
+
+    def test_get_solo_caching_uncommitted_read_in_rolled_back_transaction_does_not_poison_cache(
+        self,
+    ):
+        # Commit an initial value, then drop it from the cache so the next read
+        # is a cache miss that goes to the DB (as if SOLO_CACHE_TIMEOUT expired).
+        cfg = SiteConfiguration.get_solo()
+        cfg.site_name = "Committed"
+        cfg.save()
+        self.cache.clear()
+
+        # Inside a transaction: modify the row, then a cache-miss read repopulates
+        # the cache from the (uncommitted) DB state. The transaction then rolls back.
+        with self.assertRaises(_RollbackError), transaction.atomic():
+            cfg.site_name = "Rolled back"
+            cfg.save()
+            reread = SiteConfiguration.get_solo()
+            self.assertEqual(reread.site_name, "Rolled back")
+            raise _RollbackError
+
+        # The DB reverted to the committed value...
+        self.assertEqual(SiteConfiguration.objects.get(pk=cfg.pk).site_name, "Committed")
+        # ...and the cache must not hold the rolled-back value.
+        cached = self.cache.get(self.cache_key)
+        self.assertNotEqual(getattr(cached, "site_name", None), "Rolled back")
+        self.assertEqual(SiteConfiguration.get_solo().site_name, "Committed")


### PR DESCRIPTION
## The bug

`SingletonModel` keeps the configured cache (`SOLO_CACHE`) in sync with the DB by updating it synchronously around every DB operation. If an operation runs inside an outer `transaction.atomic()` that later **rolls back**, the database reverts but the cache keeps the value it was given. The cache then disagrees with the DB until `SOLO_CACHE_TIMEOUT` expires (5 minutes by default) or the next successful write — so `get_solo()` serves stale (or non-existent) data in the meantime.

There are three poisoning paths in `solo/models.py`:

1. **`save()`** called `self.set_to_cache()` immediately after `super().save()`. A rollback reverts the row but the cache keeps the rolled-back value. (`Model.objects.create()` routes through `save()`, so it's covered too.)
2. **`delete()`** called `self.clear_cache()` *before* `super().delete()`. A rollback keeps the row, but the cache was already emptied — so the cache is stale/empty for a row that still exists.
3. **`get_solo()`** on a cache miss did `get_or_create(pk=...)` then `obj.set_to_cache()`. This poisons the cache in two sub-cases: the row was **created** inside the transaction (and then rolled away), or the row existed but had an **uncommitted modification** earlier in the same transaction that `get_solo` read back and cached before the rollback.

## The fix

Defer every cache update to `transaction.on_commit(...)`:

- `save()` → `transaction.on_commit(self.set_to_cache)`
- `delete()` → `transaction.on_commit(self.clear_cache)`
- `get_solo()` (cache miss) → `transaction.on_commit(obj.set_to_cache)`

`on_commit` callbacks fire when the surrounding transaction commits and are discarded on rollback, so the cache only ever reflects what the DB actually committed. In autocommit mode (no surrounding transaction) the callback fires immediately, so non-transactional behaviour is unchanged.

For `get_solo()` this is both simpler and more correct than capturing `get_or_create`'s `created` flag and skipping the cache for new rows: deferring to commit closes the create-on-miss rollback case *and* the read-of-uncommitted-modification case, with no flag to track. The only behavioural change is that within a still-open transaction the cache isn't populated until commit (repeated reads hit the DB until then); the common autocommit path is unaffected.

## Tests

Added a `TransactionRollbackCacheTest` (`solo/tests/tests.py`) with a regression test per path:

- `save()` inside an `atomic()` that rolls back → cache must not hold the rolled-back value.
- `delete()` inside an `atomic()` that rolls back → cache must still hold the (not-actually-deleted) value.
- `get_solo()` create-on-miss inside an `atomic()` that rolls back → cache must not hold an object for the row that no longer exists.
- `get_solo()` re-caching an uncommitted modification inside an `atomic()` that rolls back → cache must not hold the rolled-back value.

The tests:

- use `TransactionTestCase` (not `TestCase`) — `on_commit` callbacks don't fire inside the wrapping transaction a plain `TestCase` uses, which would make the fixes look broken;
- run with `SOLO_CACHE` enabled — the fixes are no-ops when caching is off, since `set_to_cache`/`clear_cache` early-return.

I verified each new test fails against the unfixed `models.py` and passes with the fix. The existing `test_delete_if_cache_enabled` was updated to wrap `save()`/`delete()` in `captureOnCommitCallbacks(execute=True)`, since its cache assertions now depend on the deferred `on_commit` callbacks firing.

Full suite (`manage.py test solo`), `ruff format`/`ruff check`, and `mypy` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)